### PR TITLE
Fix a bug when having multiple tabs with the same file would throw an error

### DIFF
--- a/CloseTabsToRight/Commands/CloseTabsToLeftCommand.cs
+++ b/CloseTabsToRight/Commands/CloseTabsToLeftCommand.cs
@@ -1,14 +1,14 @@
-﻿using EnvDTE;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Linq;
+using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.Platform.WindowManagement;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using static CloseTabsToRight.Helpers.WindowFrameHelpers;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Design;
-using System.Linq;
 using static CloseTabsToRight.Helpers.DocumentHelpers;
+using static CloseTabsToRight.Helpers.WindowFrameHelpers;
 
 namespace CloseTabsToRight.Commands
 {

--- a/CloseTabsToRight/Commands/CloseTabsToRightCommand.cs
+++ b/CloseTabsToRight/Commands/CloseTabsToRightCommand.cs
@@ -1,15 +1,15 @@
-﻿using EnvDTE;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Linq;
+using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.Platform.WindowManagement;
 using Microsoft.VisualStudio.PlatformUI.Shell;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using static CloseTabsToRight.Helpers.WindowFrameHelpers;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Design;
-using System.Linq;
 using static CloseTabsToRight.Helpers.DocumentHelpers;
+using static CloseTabsToRight.Helpers.WindowFrameHelpers;
 
 namespace CloseTabsToRight.Commands
 {

--- a/CloseTabsToRight/Helpers/DocumentHelpers.cs
+++ b/CloseTabsToRight/Helpers/DocumentHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.Platform.WindowManagement;
 using Microsoft.VisualStudio.PlatformUI.Shell;
+using System.Text.RegularExpressions;
 
 namespace CloseTabsToRight.Helpers
 {
@@ -10,7 +11,9 @@ namespace CloseTabsToRight.Helpers
             if (string.IsNullOrEmpty(name))
                 return "";
 
-            return name.StartsWith("D:0:0:") ? name.Substring(6) : name;
+            //Name begins with "D:{number}:{number}:" where {number} can vary 
+            //depending on the number of tabs open for the same file
+            return Regex.IsMatch(name, @"^(D:\d+:\d+:)") ? name.Substring(6) : name;
         }
 
         public static DocumentGroup GetDocumentGroup(WindowFrame windowFrame)

--- a/CloseTabsToRight/Helpers/DocumentHelpers.cs
+++ b/CloseTabsToRight/Helpers/DocumentHelpers.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.VisualStudio.Platform.WindowManagement;
+﻿using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.Platform.WindowManagement;
 using Microsoft.VisualStudio.PlatformUI.Shell;
-using System.Text.RegularExpressions;
 
 namespace CloseTabsToRight.Helpers
 {


### PR DESCRIPTION
Fix a bug when having multiple tabs with the same file would throw "Item already exists in collection" error.

- Add regex to CleanDocumentViewName to match document names that start with "D:{number}:{number}:" instead of "D:0:0:" since when the same file is open in multiple tabs, the number would not be zero.

- Close all the clones of a tab